### PR TITLE
[fix] Make sure the slides are sorted

### DIFF
--- a/convertpdf.py
+++ b/convertpdf.py
@@ -16,18 +16,23 @@ def download_images(url):
     soup = BeautifulSoup(html)
     title = 'pdf_images' #soup.title.string
     images = soup.findAll('img', {'class':'slide_image'})
+    index = 0
+
+    if not os.path.exists(title):
+            os.makedirs(title)
 
     for image in images:
         image_url = image.get('data-full').split('?')[0]
-        command = 'wget %s -P %s' % (image_url, title)
+        command = 'wget %s -O %s/%09d.jpg' % (image_url, title, index)
         os.system(command)
+        index = index + 1
 
     convert_pdf(title)
 
 def convert_pdf(url):
     f = []
     for (dirpath, dirnames, filenames) in walk(join(CURRENT, url)):
-        f.extend(filenames)
+        f.extend(sorted(filenames))
         break
     f = ["%s/%s" % (url, x) for x in f]
     print f


### PR DESCRIPTION
`-O` is used as a quick and dirty way to make sure the images are easily
sortable. Previously, the counting number was burried in the image's file name.

Since wget's `-P` argument does not work in combination with `-O`,
the directory for the downloaded images has to be created by us.