### PR TITLE
Fix Slideshare July 2024 Update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,13 +3,8 @@
 Download Slideshare without login and converted into pdf with high-resolution automatically.
 
 ## Environment
-This code tested on macOS Big Sur and Python 3.10. The requirement needed are
 
-**Chromium Driver**
-
-- Download Chromium Driver [here](https://googlechromelabs.github.io/chrome-for-testing/) match with your environment (OS, Arch and Chrome Version)
-- Extract then copy to any binary path you want. ie: `/opt/local/bin/chromedriver`
-- Check permission is readable by everyone
+This code tested on Linux/Unix env and Python 3.
 
 
 ## Installation
@@ -28,14 +23,9 @@ pip3 install -r requirements.txt
 python slideshare2pdf.py [url]
 ```
 
-This will open chromium browser and automatically scroll-down to load all the slides. 
-
 Example:
 ```
 python slideshare2pdf.py https://www.slideshare.net/JiangweiPan/reward-innovation-for-longterm-member-satisfaction
 ```
 
 See the result: [reward_innovation_for_longterm_member_satisfaction.pdf](reward_innovation_for_longterm_member_satisfaction.pdf)
-
-## Notes 
-This is not working with ```headless=True```. You can use VM to run the browser.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 img2pdf
 bs4
 requests
-selenium

--- a/slideshare2pdf.py
+++ b/slideshare2pdf.py
@@ -16,50 +16,78 @@ except ImportError: from BeautifulSoup import BeautifulSoup #python2
 try: input = raw_input #python2
 except NameError: pass #python3
 
-from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.chrome.options import Options
-from selenium.webdriver.chrome.service import Service
+#from selenium import webdriver
+#from selenium.webdriver.common.by import By
+#from selenium.webdriver.support.ui import WebDriverWait
+#from selenium.webdriver.support import expected_conditions as EC
+#from selenium.webdriver.chrome.options import Options
+#from selenium.webdriver.chrome.service import Service
 
-import time 
+#import time 
 
 CURRENT = os.path.dirname(__file__)
 
-options = Options()
+#options = Options()
 
 # options.headless = True
-options.add_argument("start-maximized")
-options.add_experimental_option("excludeSwitches", ["enable-automation"])
-options.add_experimental_option('useAutomationExtension', False)
-service = Service(executable_path=r'/opt/local/bin/chromedriver')
-driver = webdriver.Chrome(service=service, options=options)
+#options.add_argument("start-maximized")
+#options.add_experimental_option("excludeSwitches", ["enable-automation"])
+#options.add_experimental_option('useAutomationExtension', False)
+#service = Service(executable_path=r'/opt/local/bin/chromedriver')
+#driver = webdriver.Chrome(service=service, options=options)
 
 def download_images(url):
-    # html = requests.get(url).content
-    driver.get(url)
-    driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+    ## Update 2024-07-17: revert to requests instead of selenium
+    html = requests.get(url).content
+    #driver.get(url)
+    #driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
 
     # modify this depend on your internet connection and the size of the slides
-    time.sleep(5)
+    #time.sleep(5)
 
     # Get the page source after interactions
-    page_source = driver.page_source.encode('utf-8')
+    #page_source = driver.page_source.encode('utf-8')
 
-    soup = BeautifulSoup(page_source, 'html.parser')
-    title = '_'.join(( '/tmp/pdf_images', strftime("%Y/%m/%d_%H:%M:%S", localtime()) ))  #soup.title.string
-    images = soup.findAll('source', {'data-testid':'slide-image-source'})
+    #soup = BeautifulSoup(page_source, 'html.parser')
+    soup = BeautifulSoup(html, 'html.parser')
+    #with open('soup.html', 'wb') as f:
+    #    f.write(soup)
 
-    print(images)
+    title = ''.join(( CURRENT + '/pdf_images', strftime("/%Y%m%d_%H%M%S", localtime()) ))  # temp img dir
 
-    driver.quit()
+    #images = soup.findAll('source', {'data-testid':'slide-image-source'})
+    ## Update 2024-07-17. Sample data:
+    # <img alt="Hands on Apache Flink
+    # How to run, debug and speed up
+    # Flink applications
+    # Robert Metzger
+    # rmetzger@apache.org
+    # @rmetzger_
+    # " class="vertical-slide-image VerticalSlideImage_image__VtE4p VerticalSlideImage_loaded__Q7FLb" data-testid="vertical-slide-image" id="slide-image-0" loading="eager" sizes="100vw" src="https://image.slidesharecdn.com/flinktroubleshooting-new-150528082323-lva1-app6892/85/Apache-Flink-Hands-On-1-320.jpg" srcset="https://image.slidesharecdn.com/flinktroubleshooting-new-150528082323-lva1-app6892/85/Apache-Flink-Hands-On-1-320.jpg 320w, https://image.slidesharecdn.com/flinktroubleshooting-new-150528082323-lva1-app6892/85/Apache-Flink-Hands-On-1-638.jpg 638w, https://image.slidesharecdn.com/flinktroubleshooting-new-150528082323-lva1-app6892/75/Apache-Flink-Hands-On-1-2048.jpg 2048w"/>
+    images = soup.find_all('img', {'data-testid':'vertical-slide-image'})
+
+    #driver.quit()
+
+    image_url = ""
+
+    # Get URL image pattern. because not all <img> contain slide URL
+    for image in images:
+        image_url = image.get('srcset').split('w, ')[-1].split(' ')[0]
+        if image_url.endswith('.jpg'):
+            break
 
     i = 1
-
+    # image_url: https://image.slidesharecdn.com/flinktroubleshooting-new-150528082323-lva1-app6892/75/Apache-Flink-Hands-On-1-2048.jpg
+    image_url_prefix = image_url.rstrip('-2048.jpg')
+    image_url_prefix = image_url_prefix.rstrip('0123456789') # remove last slide id
+    image_url_prefix = image_url_prefix.rstrip('-') # remove last -
+    pdf_f = re.sub('[^0-9a-zA-Z]+', '_', image_url_prefix.split("/")[-1]) # Get pdf name from URL image
+    pdf_f += ".pdf"
+    print("1. Download Images:")
+    # Get all slide image URL
     for image in images:
-        image_url = image.get('data-srcset').split('w, ')[-1].split(' ')[0]
-
+        image_url = image_url_prefix + '-' + str(i) + '-2048.jpg'
+        print(f"Downloading {image_url}")
         # command = "wget '%s' -P '%s' --no-check-certificate" % (image_url, title)
         # os.system(command)
         r = requests.get(image_url)
@@ -73,9 +101,10 @@ def download_images(url):
         with open(title + "/"+ filename, 'wb') as f:
             f.write(r.content)
 
-    convert_pdf(title)
+    # Next step
+    convert_pdf(title, pdf_f)
 
-def convert_pdf(img_dir_name):
+def convert_pdf(img_dir_name, pdf_f):
     f = []
     for (dirpath, dirnames, filenames) in walk(join(CURRENT, img_dir_name)):
         f.extend(filenames)
@@ -95,12 +124,15 @@ def convert_pdf(img_dir_name):
 
     f.sort(key=natural_keys)
     
+    print(f"\n2. Convert Images to PDF")
     print(f)
 
     pdf_bytes = img2pdf.convert(f, dpi=300, x=None, y=None)
     doc = open(pdf_f, 'wb')
     doc.write(pdf_bytes)
     doc.close()
+
+    print(f"\n3. Done: {pdf_f}")
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:
@@ -117,7 +149,6 @@ if __name__ == "__main__":
         pdf_f = "result.pdf"
     else:
         pdf_f+=".pdf"
+    # pdf_f: now use image URL as pdf name
 
     download_images(url)
-
-


### PR DESCRIPTION
fix: Slideshare 2024 July update
    - Revert back to requests instead for selenium
    - Change 'temp img dir' in CWD instead /tmp for compatibility to Windows env
    - Add verbose downloading and converting message
    - PDF filename now use slide image URL